### PR TITLE
Read config path from HPOS_CONFIG_PATH

### DIFF
--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -35,7 +35,9 @@ impl Keys {
 }
 
 async fn keypair_from_config() -> Result<Keypair> {
-    let config_path = "/run/hpos-init/hp-*.json";
+    let config_path =
+        env::var("HPOS_CONFIG_PATH").context("Cannot read HPOS_CONFIG_PATH from env var")?;
+
     let password = env::var("DEVICE_SEED_DEFAULT_PASSWORD")
         .context("Cannot read bundle password from env var")?;
 


### PR DESCRIPTION
Path to HPOS config is declared in HPOS profile and passed to services via HPOS_CONFIG_PATH. This PR makes netstatsd compatible with other services which prevents tests from breaking.