### PR TITLE
#41 / upload version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ HPOS daemon for collecting statistics from holoport and PUSHing them to database
 Currently script is collecting following information:
 
 ```
-  Holo Network  # can be one of devNet, alphaNet, flexNet...
-  Channel       # nix-channel that HPOS is following
-  Model         # HP or HP+
-  SSH status    # is SSH enabled?
-  ZT IP         # IP address on Zerotier network
-  IP address    # IPv4 address on internet
-  Holoport ID   # base36 encoded public key of the host
+  Holo Network    # can be one of devNet, alphaNet, flexNet...
+  Channel         # nix-channel that HPOS is following
+  Model           # HP or HP+
+  SSH status      # is SSH enabled?
+  ZT IP           # IP address on Zerotier network
+  IP address      # IPv4 address on internet
+  Holoport ID     # base36 encoded public key of the host
+  ChannelVersion  # The git revision channel that HPOS has downloaded
+  HposVersion     # The git revision that HPOS is currently running
 ```
 
 Once collected payload is signed with holoport's private key and sent to `match-service-api`.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -21,7 +21,7 @@ pub struct Stats {
     timestamp: Option<u32>,
     hpos_app_list: Option<HashMap<InstalledAppId, AppStatusFilter>>,
     channel_version: Option<String>,
-    holoport_version: Option<String>,
+    hpos_version: Option<String>,
 }
 
 impl Stats {
@@ -37,7 +37,7 @@ impl Stats {
             timestamp: None,
             hpos_app_list: get_hpos_app_health().await,
             channel_version: get_holo_nixpkgs_channel_version(),
-            holoport_version: get_holo_nixpkgs_version(),
+            hpos_version: get_holo_nixpkgs_version(),
         }
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -37,7 +37,7 @@ impl Stats {
             timestamp: None,
             hpos_app_list: get_hpos_app_health().await,
             channel_version: get_holo_nixpkgs_channel_version(),
-            hpos_version: get_holo_nixpkgs_version(),
+            hpos_version: get_hpos_nixpkgs_version(),
         }
     }
 
@@ -112,7 +112,7 @@ fn get_wan_ip() -> ExecResult {
     )
 }
 
-fn get_holo_nixpkgs_version() -> Option<String> {
+fn get_hpos_nixpkgs_version() -> Option<String> {
     let holo_nixpkgs_version_path: &str = "/etc/holo-nixpkgs-version";
     std::fs::read_to_string(holo_nixpkgs_version_path)
         .map_err(|e| {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -177,10 +177,7 @@ fn wrap(res: ExecResult) -> Option<String> {
 
 /// Parses String looking for false or true
 fn string_2_bool(val: Option<String>) -> Option<bool> {
-    if let Some(str) = val {
-        if let Ok(res) = &str.trim().parse::<bool>() {
-            return Some(*res);
-        }
+    val.and_then(|str| str.trim().parse::<bool>().ok())
+}
     }
-    None
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -179,5 +179,3 @@ fn wrap(res: ExecResult) -> Option<String> {
 fn string_2_bool(val: Option<String>) -> Option<bool> {
     val.and_then(|str| str.trim().parse::<bool>().ok())
 }
-    }
-}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -108,6 +108,18 @@ fn get_wan_ip() -> ExecResult {
     )
 }
 
+fn get_holo_nixpkgs_version() -> Option<String> {
+    let holo_nixpkgs_version_path: &str = "/etc/holo-nixpkgs-version";
+    std::fs::read_to_string(holo_nixpkgs_version_path)
+        .map_err(|e| {
+            warn!(
+                "Failed(`{}`) reading path `{holo_nixpkgs_version_path}`: {e:?}",
+                stringify!(get_holo_nixpkgs_version)
+            )
+        })
+        .ok()
+        .map(|s| s.trim().to_string())
+}
 /// Function parses result of Exec.capture()
 /// In case of a failure in execution or non-zero exit status
 /// logs an error and returns None, otherwise returns Some(stdout)

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -117,7 +117,7 @@ fn get_holo_nixpkgs_version() -> Option<String> {
     std::fs::read_to_string(holo_nixpkgs_version_path)
         .map_err(|e| {
             warn!(
-                "Failed(`{}`) reading path `{holo_nixpkgs_version_path}`: {e:?}",
+                "Failed(`{}`) while reading path `{holo_nixpkgs_version_path}`: {e:?}",
                 stringify!(get_holo_nixpkgs_version)
             )
         })
@@ -131,8 +131,8 @@ fn get_holo_nixpkgs_channel_version() -> Option<String> {
             .capture()
             .map_err(|e| {
                 warn!(
-                    "Failed(`{}`) and instantiating `<holo-nixpkgs/.git-version>`: {e:?}",
-                    stringify!(get_holo_nixpkgs_channel_version)
+                    "Failed(`{}`) while instantiating `<holo-nixpkgs/.git-version>`: {e:?}",
+                    stringify!(get_holo_nixpkgs_channel_version) 
                 )
             })
             .ok()

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -20,6 +20,8 @@ pub struct Stats {
     holoport_id: Option<String>,
     timestamp: Option<u32>,
     hpos_app_list: Option<HashMap<InstalledAppId, AppStatusFilter>>,
+    channel_version: Option<String>,
+    holoport_version: Option<String>,
 }
 
 impl Stats {
@@ -34,6 +36,8 @@ impl Stats {
             holoport_id: Some(pubkey_base36.to_owned()),
             timestamp: None,
             hpos_app_list: get_hpos_app_health().await,
+            channel_version: get_holo_nixpkgs_channel_version(),
+            holoport_version: get_holo_nixpkgs_version(),
         }
     }
 


### PR DESCRIPTION
HoloPorts currently auto-update from a hydra channel every 10 minutes. This PR makes failures to update more visible by sending the current `holo-nixpkgs` channel version and the version of the `holo-nixpkgs` channel that the `current-system` is built against, introduced in PR [Holo-Host/holo-nixpkgs#1205](https://github.com/Holo-Host/holo-nixpkgs/pull/1205). 

This adds the functions necessary to read the [version information](https://github.com/Holo-Host/holo-nixpkgs/pull/1205) from the system and the `holo-nixpkgs` channel and then send it to [Holo-Host/hp-stats-api](https://github.com/Holo-Host/hp-stats-api).

---

Addresses part of: https://github.com/Holo-Host/bugs-n-issues/issues/41
Depends on: https://github.com/Holo-Host/holo-nixpkgs/pull/1205
Additional Work:  https://github.com/Holo-Host/hp-stats-api/pull/19